### PR TITLE
Add support for source archives

### DIFF
--- a/src/cli/handlers/download.rs
+++ b/src/cli/handlers/download.rs
@@ -60,10 +60,12 @@ impl DownloadHandler {
             let tarball = Asset {
                 name: format!("{}.tar.gz", base_name),
                 download_url: release.tarball,
+                display_name: Some("Source code (tar.gz)".to_string()),
             };
             let zipball = Asset {
                 name: format!("{}.zip", base_name),
                 download_url: release.zipball,
+                display_name: Some("Source code (zip)".to_string()),
             };
 
             let assets = release

--- a/src/cli/handlers/download.rs
+++ b/src/cli/handlers/download.rs
@@ -124,15 +124,15 @@ impl DownloadHandler {
         selected_asset: &Asset,
         output_path: &Path,
     ) -> Result<(), HandlerError> {
+        let progress_bar = ProgressBar::download(&selected_asset.name, output_path);
+        progress_bar.start();
         let (mut stream, maybe_content_length) =
             github::download_asset(client, selected_asset).map_err(Self::download_error)?;
-        let progress_bar = ProgressBar::download(&selected_asset.name, output_path);
         if let Some(cl) = maybe_content_length {
             progress_bar.set_max_progress(cl);
         } else {
             progress_bar.progress_unknown();
         }
-        progress_bar.start();
         let mut destination = Self::create_file(output_path)?;
         let mut downloaded = 0;
         let mut buffer = [0; 1024];

--- a/src/cli/progress_bar.rs
+++ b/src/cli/progress_bar.rs
@@ -16,7 +16,7 @@ impl ProgressBar {
         pb.set_style(
             ProgressStyle::default_spinner()
                 .tick_strings(cli::spinner::TICKS)
-                .template("{spinner:.blue} {msg} {percent}% ({eta})")
+                .template("{spinner:.blue} {msg}")
                 .unwrap(),
         );
         pb.set_message(message);
@@ -42,6 +42,12 @@ impl ProgressBar {
     }
 
     pub fn set_max_progress(&self, progress: u64) {
+        self.pb.set_style(
+            ProgressStyle::default_spinner()
+                .tick_strings(cli::spinner::TICKS)
+                .template("{spinner:.blue} {msg} {percent}% ({eta})")
+                .unwrap(),
+        );
         self.pb.set_length(progress);
     }
 

--- a/src/cli/progress_bar.rs
+++ b/src/cli/progress_bar.rs
@@ -32,6 +32,15 @@ impl ProgressBar {
         println!("{}", &self.end_message);
     }
 
+    pub fn progress_unknown(&self) {
+        self.pb.set_style(
+            ProgressStyle::default_spinner()
+                .tick_strings(cli::spinner::TICKS)
+                .template("{spinner:.blue} {msg} {bytes}")
+                .unwrap(),
+        )
+    }
+
     pub fn set_max_progress(&self, progress: u64) {
         self.pb.set_length(progress);
     }

--- a/src/cli/select.rs
+++ b/src/cli/select.rs
@@ -28,10 +28,13 @@ pub fn ask_select_asset(assets: Vec<Asset>, messages: Messages) -> AskSelectAsse
 fn assets_names(assets: &[Asset]) -> Vec<String> {
     assets
         .iter()
-        .map(|x| x.name.clone())
+        .map(|x| x.display_name.clone().unwrap_or_else(|| x.name.clone()))
         .collect::<Vec<String>>()
 }
 
 fn find_asset_by_name(name: &str, assets: Vec<Asset>) -> Asset {
-    assets.into_iter().find(|x| x.name == name).unwrap()
+    assets
+        .into_iter()
+        .find(|x| x.display_name.as_deref().filter(|&n| n == name).is_some() || x.name == name)
+        .unwrap()
 }

--- a/src/github/error.rs
+++ b/src/github/error.rs
@@ -4,7 +4,6 @@ use std::fmt::Formatter;
 pub enum GithubError {
     Http(Box<ureq::Error>),
     JsonDeserialization(std::io::Error),
-    InvalidContentLength,
     RepositoryOrReleaseNotFound,
     RateLimitExceeded,
     Unauthorized,
@@ -28,9 +27,6 @@ impl std::fmt::Display for GithubError {
             GithubError::Http(e) => f.write_str(&e.to_string()),
             GithubError::JsonDeserialization(e) => {
                 f.write_str(&format!("Error deserializing response: {}", e))
-            }
-            GithubError::InvalidContentLength => {
-                f.write_str("Content-Length header is missing or invalid")
             }
             GithubError::RepositoryOrReleaseNotFound => {
                 f.write_str("Repository or release not found")

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -49,15 +49,14 @@ fn deserialize(response: ureq::Response) -> Result<Release, GithubError> {
 pub fn download_asset(
     client: &GithubClient,
     asset: &Asset,
-) -> Result<(impl Read + Send, u64), GithubError> {
+) -> Result<(impl Read + Send, Option<u64>), GithubError> {
     let response = client
         .get(&asset.download_url)
-        .set("Accept", "application/octet-stream")
+        .set("Accept", "application/vnd.github.raw")
         .call()
         .map_err(GithubError::from)?;
     let content_length = response
         .header("Content-Length")
-        .and_then(|v| v.parse().ok())
-        .ok_or(GithubError::InvalidContentLength)?;
+        .and_then(|v| v.parse().ok());
     Ok((response.into_reader(), content_length))
 }

--- a/src/github/release.rs
+++ b/src/github/release.rs
@@ -14,6 +14,8 @@ pub struct Asset {
     pub name: String,
     #[serde(rename(deserialize = "browser_download_url"))]
     pub download_url: String,
+    #[serde(skip)]
+    pub display_name: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/github/release.rs
+++ b/src/github/release.rs
@@ -12,7 +12,7 @@ impl Tag {
 #[derive(Deserialize, Debug)]
 pub struct Asset {
     pub name: String,
-    #[serde(rename(deserialize = "url"))]
+    #[serde(rename(deserialize = "browser_download_url"))]
     pub download_url: String,
 }
 
@@ -20,5 +20,9 @@ pub struct Asset {
 pub struct Release {
     #[serde(rename(deserialize = "tag_name"))]
     pub tag: Tag,
+    #[serde(rename(deserialize = "tarball_url"))]
+    pub tarball: String,
+    #[serde(rename(deserialize = "zipball_url"))]
+    pub zipball: String,
     pub assets: Vec<Asset>,
 }

--- a/src/github/tagged_asset.rs
+++ b/src/github/tagged_asset.rs
@@ -59,6 +59,7 @@ mod tests {
         Asset {
             name: name.to_string(),
             download_url: "ANY_DOWNLOAD_URL".to_string(),
+            display_name: None,
         }
     }
 }


### PR DESCRIPTION
Closes #52

Adding as draft to initiate discussion.

Important notes:

- switched the url used for normal assets to `browser_download_url` to make the common accepted content type `application/vnd.github.raw` work uniformly
- the progress bar displays just the downloaded bytes if the content length is unknown
- skipped implementing this feature for `untag` for now